### PR TITLE
changed router mode to createWebHashHistory, so URLs work on fleek

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,4 +1,4 @@
-import { createWebHistory, createRouter } from 'vue-router'
+import { createWebHashHistory, createRouter } from 'vue-router'
 import HomePage from '@/pages/HomePage.vue'
 
 const routes = [
@@ -24,7 +24,7 @@ const routes = [
 ]
 
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHashHistory(),
   routes,
   scrollBehavior(to, from, savedPosition) {
     if (savedPosition) {


### PR DESCRIPTION
URLs will now look like `https://dao.vitadao.com/#/proposal/50` instead of `https://dao.vitadao.com/proposal/50`

This will make all routes work on fleek, since it doesn't seem to support the history mode for regular URLs. We should change this in the future since real URLs are just nicer and also work better for SEO.