### PR TITLE
Add DAO event stream to subgraph

### DIFF
--- a/subgraph/generated/schema.ts
+++ b/subgraph/generated/schema.ts
@@ -619,3 +619,192 @@ export class Voter extends Entity {
     this.set("votes", Value.fromStringArray(value));
   }
 }
+
+export class ProposalStatusChanged extends Entity {
+  constructor(id: string) {
+    super();
+    this.set("id", Value.fromString(id));
+  }
+
+  save(): void {
+    let id = this.get("id");
+    assert(
+      id !== null,
+      "Cannot save ProposalStatusChanged entity without an ID"
+    );
+    assert(
+      id.kind == ValueKind.STRING,
+      "Cannot save ProposalStatusChanged entity with non-string ID. " +
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("ProposalStatusChanged", id.toString(), this);
+  }
+
+  static load(id: string): ProposalStatusChanged | null {
+    return store.get(
+      "ProposalStatusChanged",
+      id
+    ) as ProposalStatusChanged | null;
+  }
+
+  get id(): string {
+    let value = this.get("id");
+    return value.toString();
+  }
+
+  set id(value: string) {
+    this.set("id", Value.fromString(value));
+  }
+
+  get type(): string {
+    let value = this.get("type");
+    return value.toString();
+  }
+
+  set type(value: string) {
+    this.set("type", Value.fromString(value));
+  }
+
+  get createdAt(): BigInt {
+    let value = this.get("createdAt");
+    return value.toBigInt();
+  }
+
+  set createdAt(value: BigInt) {
+    this.set("createdAt", Value.fromBigInt(value));
+  }
+
+  get proposal(): string {
+    let value = this.get("proposal");
+    return value.toString();
+  }
+
+  set proposal(value: string) {
+    this.set("proposal", Value.fromString(value));
+  }
+
+  get newStatus(): string {
+    let value = this.get("newStatus");
+    return value.toString();
+  }
+
+  set newStatus(value: string) {
+    this.set("newStatus", Value.fromString(value));
+  }
+}
+
+export class ProposalCreated extends Entity {
+  constructor(id: string) {
+    super();
+    this.set("id", Value.fromString(id));
+  }
+
+  save(): void {
+    let id = this.get("id");
+    assert(id !== null, "Cannot save ProposalCreated entity without an ID");
+    assert(
+      id.kind == ValueKind.STRING,
+      "Cannot save ProposalCreated entity with non-string ID. " +
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("ProposalCreated", id.toString(), this);
+  }
+
+  static load(id: string): ProposalCreated | null {
+    return store.get("ProposalCreated", id) as ProposalCreated | null;
+  }
+
+  get id(): string {
+    let value = this.get("id");
+    return value.toString();
+  }
+
+  set id(value: string) {
+    this.set("id", Value.fromString(value));
+  }
+
+  get type(): string {
+    let value = this.get("type");
+    return value.toString();
+  }
+
+  set type(value: string) {
+    this.set("type", Value.fromString(value));
+  }
+
+  get createdAt(): BigInt {
+    let value = this.get("createdAt");
+    return value.toBigInt();
+  }
+
+  set createdAt(value: BigInt) {
+    this.set("createdAt", Value.fromBigInt(value));
+  }
+
+  get proposal(): string {
+    let value = this.get("proposal");
+    return value.toString();
+  }
+
+  set proposal(value: string) {
+    this.set("proposal", Value.fromString(value));
+  }
+}
+
+export class Voted extends Entity {
+  constructor(id: string) {
+    super();
+    this.set("id", Value.fromString(id));
+  }
+
+  save(): void {
+    let id = this.get("id");
+    assert(id !== null, "Cannot save Voted entity without an ID");
+    assert(
+      id.kind == ValueKind.STRING,
+      "Cannot save Voted entity with non-string ID. " +
+        'Considering using .toHex() to convert the "id" to a string.'
+    );
+    store.set("Voted", id.toString(), this);
+  }
+
+  static load(id: string): Voted | null {
+    return store.get("Voted", id) as Voted | null;
+  }
+
+  get id(): string {
+    let value = this.get("id");
+    return value.toString();
+  }
+
+  set id(value: string) {
+    this.set("id", Value.fromString(value));
+  }
+
+  get type(): string {
+    let value = this.get("type");
+    return value.toString();
+  }
+
+  set type(value: string) {
+    this.set("type", Value.fromString(value));
+  }
+
+  get createdAt(): BigInt {
+    let value = this.get("createdAt");
+    return value.toBigInt();
+  }
+
+  set createdAt(value: BigInt) {
+    this.set("createdAt", Value.fromBigInt(value));
+  }
+
+  get vote(): string {
+    let value = this.get("vote");
+    return value.toString();
+  }
+
+  set vote(value: string) {
+    this.set("vote", Value.fromString(value));
+  }
+}

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -87,3 +87,36 @@ type Voter @entity {
   id: ID!
   votes: [Vote]! @derivedFrom(field: "voter")
 }
+
+"""
+DAO Events
+"""
+
+interface DaoEvent {
+  "Concatenation of block number and log ID"
+  id: ID!
+  type: String!
+  createdAt: BigInt!
+}
+
+type ProposalStatusChanged implements DaoEvent @entity {
+  id: ID!
+  type: String!
+  createdAt: BigInt!
+  proposal: Proposal!
+  newStatus: ProposalStatus!
+}
+
+type ProposalCreated implements DaoEvent @entity {
+  id: ID!
+  type: String!
+  createdAt: BigInt!
+  proposal: Proposal!
+}
+
+type Voted implements DaoEvent @entity {
+  id: ID!
+  type: String!
+  createdAt: BigInt!
+  vote: Vote!
+}


### PR DESCRIPTION
Currently, we're listing the latest proposal votes on the Dapp home page. Since there are a lot of other relevant on-chain events, I created a new DaoEvent interface in the subgraph, in order to be able to unify those events in the future. 

Possible events/use cases in the future: 
- Votes (already in use)
- Proposal creation/update
- Treasury transactions
- VitaDAO multisig transactions (payouts & funding from working groups)
- IP-NFT transactions
- Auctions/Buyouts of fractionalized IP-NFTs
- ...

The DAOEvent interface implements the following fields (those are required for every event, which implements the interface):

```
interface DaoEvent {
  "Concatenation of block number and log ID"
  id: ID!
  type: String!
  createdAt: BigInt!
}
```

Here's an example query that shows how to get the specific graphql fields for the different event types: 
```
{
 
  daoEvents(first:10) {
    id
    createdAt
    type
    ...on Voted {
      vote {
        direction
        weight
        voter {
          id
        }
      }
    }
    ...on ProposalCreated {
      proposal {
        proposalContent {
          title
        }
      }
    }
  }
}
```

**After the merge of this PR I will update the actual dapp client code to query the new DAOEvent entity, instead of only the latest votes.**