### PR TITLE
Feeding router to gtag to make it work.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -91,9 +91,15 @@ createApp({
 
   render: () => h(App),
 })
-  .use(VueGtag, {
-    config: { id: process.env.VUE_APP_GOOGLE_TAG_MANAGER_ID },
-  })
+  .use(
+    VueGtag,
+    {
+      config: {
+        id: process.env.VUE_APP_GOOGLE_TAG_MANAGER_ID,
+      },
+    },
+    router,
+  )
   .use(store)
   .use(router)
   .use(Toast)

--- a/src/main.js
+++ b/src/main.js
@@ -91,6 +91,8 @@ createApp({
 
   render: () => h(App),
 })
+  .use(router)
+  .use(store)
   .use(
     VueGtag,
     {
@@ -100,8 +102,6 @@ createApp({
     },
     router,
   )
-  .use(store)
-  .use(router)
   .use(Toast)
   .component('fa', FontAwesomeIcon)
   .mount('#app')


### PR DESCRIPTION
This adds the router to the gtag package instantiation, which makes any navigation result in firing a gtag event. 