### PR TITLE
Hide inaccurate treasury data

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -67,10 +67,6 @@ export default defineComponent({
         name: 'Proposals',
         to: '/proposals',
       },
-      {
-        name: 'Treasury',
-        to: '/treasury',
-      },
       { name: 'Wallet', to: '/wallet' },
     ]
 

--- a/src/components/DaoStats.vue
+++ b/src/components/DaoStats.vue
@@ -1,6 +1,21 @@
 <template>
   <p v-if="statsStatus === 'error'" class="text-red-500">{{ statsError.message }}</p>
   <div v-else class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4 auto-rows-[160px]">
+    <div
+      class="bg-vita-purple text-white rounded-2xl px-8 py-5 flex flex-col justify-between flex-1"
+    >
+      <span class="flex items-start text-xl gap-1">
+        $
+        <span v-if="statsStatus === 'success'" class="font-medium text-[42px] leading-[1em]">{{
+          statsData.vita.price
+        }}</span>
+        <span
+          v-else
+          class="bg-vita-purple brightness-[0.9] animate-pulse h-[42px] w-[8ch] text-[42px] rounded-sm"
+        />
+      </span>
+      <span>$VITA price</span>
+    </div>
     <div class="bg-vita-sunrise rounded-2xl px-8 py-5 flex flex-col justify-between flex-1 gap-3">
       <span v-if="statsStatus === 'success'" class="font-medium text-[42px] leading-[1em]">{{
         statsData.vita.circulating

--- a/src/components/DaoStats.vue
+++ b/src/components/DaoStats.vue
@@ -1,28 +1,6 @@
 <template>
   <p v-if="statsStatus === 'error'" class="text-red-500">{{ statsError.message }}</p>
   <div v-else class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4 auto-rows-[160px]">
-    <div
-      class="bg-vita-purple text-white rounded-2xl px-8 py-5 flex flex-col justify-between flex-1"
-    >
-      <div>
-        <span class="flex items-start text-xl gap-1">
-          $
-          <span v-if="usdTotal" class="font-medium text-[42px] leading-[1em]">{{ usdTotal }}</span>
-          <span
-            v-else
-            class="bg-vita-purple brightness-[0.9] animate-pulse h-[42px] w-[8ch] text-[42px] rounded-sm"
-          />
-        </span>
-        <span v-if="usdDelta" class="text-[20px]"
-          >{{ usdDelta }} <span class="opacity-50">weekly</span></span
-        >
-        <span
-          v-else
-          class="bg-vita-purple brightness-[0.9] animate-pulse h-[20px] w-[8ch] text-[20px] rounded-sm"
-        />
-      </div>
-      <span>Treasury value</span>
-    </div>
     <div class="bg-vita-sunrise rounded-2xl px-8 py-5 flex flex-col justify-between flex-1 gap-3">
       <span v-if="statsStatus === 'success'" class="font-medium text-[42px] leading-[1em]">{{
         statsData.vita.circulating
@@ -63,11 +41,7 @@
 </template>
 
 <script setup>
-import { useDaoStats, useUsdTimeseries } from '@/utils/queries'
-import { ref } from 'vue'
+import { useDaoStats } from '@/utils/queries'
 
 const { data: statsData, error: statsError, status: statsStatus } = useDaoStats()
-
-const interval = ref('1W')
-const { usdTotal, usdDelta } = useUsdTimeseries(interval)
 </script>

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -37,20 +37,6 @@
   </div>
   <div class="w-full">
     <hr class="border-black mb-8" />
-    <h2 class="font-medium mb-1.5 sm:mb-4 text-black text-2xl sm:text-3xl">Treasury</h2>
-    <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
-      <treasury-chart />
-      <treasury-list />
-    </div>
-    <router-link
-      to="/treasury"
-      class="mt-6 ml-auto w-max bg-white rounded-full border border-gray-300 text-center px-4 py-2 self-end flex gap-6 items-center"
-      >View more
-      <fa icon="chevron-right" class="text-xs" />
-    </router-link>
-  </div>
-  <div class="w-full">
-    <hr class="border-black mb-8" />
     <h2 class="font-medium mb-1.5 sm:mb-4 text-black text-2xl sm:text-3xl">Past proposals</h2>
     <transition name="fade" mode="out-in">
       <loading-indicator v-if="loading">Loading past proposals…</loading-indicator>
@@ -90,8 +76,6 @@
 import DaoStats from '@/components/DaoStats.vue'
 import LoadingIndicator from '@/components/LoadingIndicator'
 import SnapshotProposalBox from '@/components/SnapshotProposalBox.vue'
-import TreasuryChart from '@/components/TreasuryChart.vue'
-import TreasuryList from '@/components/TreasuryList.vue'
 import { shortenAddress } from '@/utils'
 import { useQuery } from '@vue/apollo-composable'
 import dayjs from 'dayjs'
@@ -100,7 +84,7 @@ import gql from 'graphql-tag'
 import { defineComponent } from 'vue'
 
 export default defineComponent({
-  components: { DaoStats, SnapshotProposalBox, LoadingIndicator, TreasuryChart, TreasuryList },
+  components: { DaoStats, SnapshotProposalBox, LoadingIndicator },
   setup() {
     dayjs.extend(relativeTime)
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -13,11 +13,6 @@ const routes = [
     component: () => import(/* webpackChunkName: "ProposalsPage" */ '../pages/SnapshotPage.vue'),
   },
   {
-    path: '/treasury',
-    name: 'TreasuryPage',
-    component: () => import(/* webpackChunkName: "TreasuryPage" */ '../pages/TreasuryPage.vue'),
-  },
-  {
     path: '/wallet',
     name: 'WalletPage',
     component: () => import(/* webpackChunkName: "WalletPage" */ '../pages/WalletPage.vue'),

--- a/src/utils/queries.js
+++ b/src/utils/queries.js
@@ -21,7 +21,7 @@ export function useDaoStats() {
               vita: {
                 circulating: format(circulating, 0),
                 marketCap: format(market_cap, 0),
-                price: format(price, 3),
+                price: format(price, 2),
               },
               totalInvestment: format(3.5, 1) + 'M+',
             }

--- a/src/utils/queries.js
+++ b/src/utils/queries.js
@@ -16,13 +16,14 @@ export function useDaoStats() {
         .then((res) => res.json())
         .then((json) => {
           if (json.status === 'success') {
-            const { circulating, market_cap } = json.results[0]
+            const { circulating, market_cap, price } = json.results[0]
             return {
               vita: {
                 circulating: format(circulating, 0),
                 marketCap: format(market_cap, 0),
+                price: format(price, 3),
               },
-              totalInvestment: '3.5M+',
+              totalInvestment: format(3.5, 1) + 'M+',
             }
           } else if (json.status === 'error') {
             throw new Error(json.message)

--- a/src/utils/queries.js
+++ b/src/utils/queries.js
@@ -22,7 +22,7 @@ export function useDaoStats() {
                 circulating: format(circulating, 0),
                 marketCap: format(market_cap, 0),
               },
-              totalInvestment: '3.570.000',
+              totalInvestment: '3.5M+',
             }
           } else if (json.status === 'error') {
             throw new Error(json.message)


### PR DESCRIPTION
Following discussions on Discord, the consensus seems to be that we'd prefer to roll back the recent [treasury work](https://github.com/VitaDAO/VitaDAO-dapp/pull/59) or at least hide these elements until we've improved the accuracy of the data:

![offending-parts](https://user-images.githubusercontent.com/23662058/213682416-74008e96-ebf0-44fe-b4fa-6ded93e40c38.png)