### PR TITLE
Add molecules display to AssetRow

### DIFF
--- a/src/components/AssetRow.vue
+++ b/src/components/AssetRow.vue
@@ -27,6 +27,9 @@
         <span v-if="props.asset.balance">{{
           `${formatNumber(props.asset.balance)} ${props.asset.symbol}`
         }}</span>
+        <span v-else-if="props.asset.moleculesBalance"
+          >{{ `${formatNumber(props.asset.moleculesBalance)} ${props.asset.moleculesSymbol}` }}
+        </span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR conditionally displays molecules balance if they're present, so it'll make the frontend ready to display the new IP-NFT v2 data coming from bio.xyz's API.