### PR TITLE
Improve handling of low amounts

### DIFF
--- a/src/components/AssetRow.vue
+++ b/src/components/AssetRow.vue
@@ -23,7 +23,7 @@
         </div>
       </div>
       <div class="px-2 py-3 text-right flex flex-col flex-shrink-0">
-        <span>${{ formatNumber(props.asset.value, 0) }}</span>
+        <span>${{ formatNumber(props.asset.value, { decimals: 0 }) }}</span>
         <span v-if="props.asset.balance">{{
           `${formatNumber(props.asset.balance)} ${props.asset.symbol}`
         }}</span>

--- a/src/pages/TreasuryPage.vue
+++ b/src/pages/TreasuryPage.vue
@@ -42,18 +42,20 @@
           <p v-if="section.comment" class="text-xs sm:text-base">{{ section.comment }}</p>
           <!-- Section has subsections -->
           <template v-if="typeOfChildren(section) === 'group'">
-            <div v-for="subsection of section.children" :key="subsection.label">
-              <h4 class="font-bold py-2 text-xs sm:text-base">{{ subsection.label }}</h4>
-              <template
-                v-if="['fungible-asset', 'generic-asset'].includes(typeOfChildren(subsection))"
-              >
-                <AssetRow
-                  v-for="asset of subsection.children.filter((asset) => asset.value > 1)"
-                  :key="asset.label + asset.secondaryLabel"
-                  :asset="asset"
-                />
-              </template>
-            </div>
+            <template v-for="subsection of section.children" :key="subsection.label">
+              <div v-if="subsection.value >= 100">
+                <h4 class="font-bold py-2 text-xs sm:text-base">{{ subsection.label }}</h4>
+                <template
+                  v-if="['fungible-asset', 'generic-asset'].includes(typeOfChildren(subsection))"
+                >
+                  <AssetRow
+                    v-for="asset of subsection.children.filter((asset) => asset.value > 1)"
+                    :key="asset.label + asset.secondaryLabel"
+                    :asset="asset"
+                  />
+                </template>
+              </div>
+            </template>
           </template>
           <!-- Section just contains a list of assets -->
           <template v-if="['fungible-asset', 'generic-asset'].includes(typeOfChildren(section))">

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -39,7 +39,7 @@ export function capitalize(word) {
     .join('')
 }
 
-export function formatNumber(n, decimals) {
+export function formatNumber(n, { decimals, cutoff = 1000 } = {}) {
   if (decimals || decimals == 0) {
     return n?.toLocaleString(undefined, {
       minimumFractionDigits: decimals,
@@ -47,7 +47,7 @@ export function formatNumber(n, decimals) {
     })
   }
 
-  if (n >= 1000) {
+  if (n >= cutoff) {
     return n.toLocaleString(undefined, {
       minimumFractionDigits: 0,
       maximumFractionDigits: 0,

--- a/src/utils/queries.js
+++ b/src/utils/queries.js
@@ -12,11 +12,11 @@ export function useDaoStats() {
             const { circulating, market_cap, price } = json.results[0]
             return {
               vita: {
-                circulating: formatNumber(circulating, 0),
-                marketCap: formatNumber(market_cap, 0),
-                price: formatNumber(price, 2),
+                circulating: formatNumber(circulating, { decimals: 0 }),
+                marketCap: formatNumber(market_cap, { decimals: 0 }),
+                price: formatNumber(price, { decimals: 2 }),
               },
-              totalInvestment: formatNumber(4, 0) + 'M+',
+              totalInvestment: formatNumber(4, { decimals: 0 }) + 'M+',
             }
           } else if (json.status === 'error') {
             throw new Error(json.message)


### PR DESCRIPTION
Some changes aimed at improving handling of low amounts on the treasury page. Before this PR, rows with low amounts are hidden, ending up with weird artefacts like this seemingly duplicated sub-group heading:

<img width="580" alt="low-amounts-issue" src="https://github.com/VitaDAO/VitaDAO-dapp/assets/23662058/2fcc7104-5b91-4da5-bd2d-dddfc4d2d5a6">

This PR provides a quick fix that hides groups with value < 100 that given the amounts in the treasury page, really just tend to add noise. 